### PR TITLE
fix: add `type` to get kirby-cli working

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "kirby-analytics-dashboard",
   "version": "1.0.0",
+  "type": "kirby-plugin",
   "description": "Kirby Analytics Dashboard is a Kirby plugin which extends your dashboard with some Google Analytics statistics and reports.",
   "dependencies": {
     "chart.js": "^2.7.1",


### PR DESCRIPTION
I add the property `type` with value `kirby-plugin`, to get `kirby plugin:install` working.